### PR TITLE
remove typo and change word order on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     
     <main>
         <header>
-            <h1>Web Developer by employe, <br> Designer by freelance.</h1>
+            <h1>Web Developer and<br>Freelance Designer</h1>
             <nav>
                 <a href="https://github.com/sofiangrh" target="_blank" noopener="true" noreferer="true">GitHub</a>
                 <a href="https://instagram.com/sofiangrh" target=_blank>Instagram</a>


### PR DESCRIPTION
This commit changes "Web Developer by employe,
Designer by freelance." to "Web Developer and
Freelance Designer". Hope it helps!

Appearance of home page at the time of this writing without this change:

![image](https://user-images.githubusercontent.com/43425812/118889942-bd9ffb80-b8b2-11eb-88f7-9c479a357516.png)

Appearance if we merge this pull request:

![image](https://user-images.githubusercontent.com/43425812/118889990-ce507180-b8b2-11eb-943c-4a8baca634b3.png)